### PR TITLE
Auditrep implementation

### DIFF
--- a/.github/workflows/qdao-node.yml
+++ b/.github/workflows/qdao-node.yml
@@ -60,9 +60,6 @@ jobs:
           
       - uses: actions/checkout@v3
       
-      - name: Remove Cargo.lock
-        run: rm ./qdao-node/Cargo.lock
-      
       - name: Cargo build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/qdao-node.yml
+++ b/.github/workflows/qdao-node.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           toolchain: nightly
           command: fmt
-          args: --all --locked --manifest-path ./qdao-node/Cargo.toml -- --check
+          args: --all --manifest-path ./qdao-node/Cargo.toml -- --check
 
   clippy:
     runs-on: 'ubuntu-latest'

--- a/qdao-node/audit-pallet/src/mock.rs
+++ b/qdao-node/audit-pallet/src/mock.rs
@@ -1,5 +1,8 @@
 use crate as qdao_pallet_dummy;
-use frame_support::{traits::{ConstU16, ConstU64}, parameter_types};
+use frame_support::{
+    parameter_types,
+    traits::{ConstU16, ConstU64},
+};
 use frame_system as system;
 use sp_core::H256;
 use sp_runtime::{
@@ -70,7 +73,7 @@ impl qdao_pallet_dummy::Config for Test {
     type Event = Event;
     type Balance = u64;
     type Currency = Balances;
-    type MinAuditorStake =frame_support::traits::ConstU64<100>;
+    type MinAuditorStake = frame_support::traits::ConstU64<100>;
 }
 
 // // Build genesis storage according to the mock runtime.

--- a/qdao-node/audit-pallet/src/tests.rs
+++ b/qdao-node/audit-pallet/src/tests.rs
@@ -13,7 +13,7 @@ fn sign_up_works() {
 
         // When
         // Sign up a new auditor, should work
-        assert_ok!(AuditRepModule::sign_up(Origin::signed(1), hash, 50));
+        assert_ok!(AuditRepModule::sign_up(Origin::signed(1), hash, 10));
 
         // Then
         let auditor_score = AuditorScore::<Test>::try_get(sender);
@@ -24,20 +24,41 @@ fn sign_up_works() {
 }
 
 #[test]
+fn sign_up_fails_when_stake_too_low() {
+    new_test_ext().execute_with(|| {
+
+        // Given
+        let auditor = Origin::signed(1);
+        let hash = H256::repeat_byte(1);
+        let stake = 50;
+
+        // When
+        let result = AuditRepModule::sign_up(auditor, hash, stake);
+
+        // Then
+        assert_noop!(
+            result,
+            Error::<Test>::InsufficientStake
+        );
+    });
+}
+
+#[test]
 fn correct_error_for_double_sign_up() {
     new_test_ext().execute_with(|| {
 
         // Given
         let auditor1 = Origin::signed(1);
         let auditor2 = Origin::signed(2);
+        let stake = 100;
 
         // When
         // Sign up Auditor, should work
-        assert_ok!(AuditRepModule::sign_up(auditor1.clone(), H256::repeat_byte(1), 100));
+        assert_ok!(AuditRepModule::sign_up(auditor1.clone(), H256::repeat_byte(1), stake));
         //Sign up second (different) auditor, should also work
-        assert_ok!(AuditRepModule::sign_up(auditor2, H256::repeat_byte(1), 100));
+        assert_ok!(AuditRepModule::sign_up(auditor2, H256::repeat_byte(1), stake));
         // Sign up an already signed up auditor, should return an error
-        let result = AuditRepModule::sign_up(auditor1, H256::repeat_byte(1), 100);
+        let result = AuditRepModule::sign_up(auditor1, H256::repeat_byte(1), stake);
 
         // Then
         assert_noop!(

--- a/qdao-node/audit-pallet/src/tests.rs
+++ b/qdao-node/audit-pallet/src/tests.rs
@@ -6,7 +6,6 @@ use sp_core::H256;
 #[test]
 fn sign_up_works() {
     new_test_ext().execute_with(|| {
-
         // Given
         let sender = ensure_signed(Origin::signed(1)).unwrap();
         let hash = H256::repeat_byte(1);
@@ -26,7 +25,6 @@ fn sign_up_works() {
 #[test]
 fn sign_up_fails_when_stake_too_low() {
     new_test_ext().execute_with(|| {
-
         // Given
         let auditor = Origin::signed(1);
         let hash = H256::repeat_byte(1);
@@ -36,17 +34,13 @@ fn sign_up_fails_when_stake_too_low() {
         let result = AuditRepModule::sign_up(auditor, hash, stake);
 
         // Then
-        assert_noop!(
-            result,
-            Error::<Test>::InsufficientStake
-        );
+        assert_noop!(result, Error::<Test>::InsufficientStake);
     });
 }
 
 #[test]
 fn correct_error_for_double_sign_up() {
     new_test_ext().execute_with(|| {
-
         // Given
         let auditor1 = Origin::signed(1);
         let auditor2 = Origin::signed(2);
@@ -54,16 +48,21 @@ fn correct_error_for_double_sign_up() {
 
         // When
         // Sign up Auditor, should work
-        assert_ok!(AuditRepModule::sign_up(auditor1.clone(), H256::repeat_byte(1), stake));
+        assert_ok!(AuditRepModule::sign_up(
+            auditor1.clone(),
+            H256::repeat_byte(1),
+            stake
+        ));
         //Sign up second (different) auditor, should also work
-        assert_ok!(AuditRepModule::sign_up(auditor2, H256::repeat_byte(1), stake));
+        assert_ok!(AuditRepModule::sign_up(
+            auditor2,
+            H256::repeat_byte(1),
+            stake
+        ));
         // Sign up an already signed up auditor, should return an error
         let result = AuditRepModule::sign_up(auditor1, H256::repeat_byte(1), stake);
 
         // Then
-        assert_noop!(
-            result,
-            Error::<Test>::AlreadySignedUp
-        );
+        assert_noop!(result, Error::<Test>::AlreadySignedUp);
     });
 }

--- a/qdao-node/exo-pallet/src/lib.rs
+++ b/qdao-node/exo-pallet/src/lib.rs
@@ -11,6 +11,7 @@ use frame_system::Config as SystemConfig;
 pub use pallet::*;
 use scale_info::TypeInfo;
 use sp_std::prelude::*;
+use qdao_audit_pallet::{Game};
 
 #[cfg(test)]
 mod mock;
@@ -178,7 +179,7 @@ pub mod pallet {
             result: Vec<u8>,
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let review = ReviewRecord::<T>::get(challenged_hash).ok_or(Err(NoneValue))?;
+            let review = ReviewRecord::<T>::get(challenged_hash).ok_or(Error::<T>::NoneValue)?;
             // TODO Not all challenges should win, right? :smile:
             T::Game::apply_result(sender, review.author, qdao_audit_pallet::Winner::Player0)?;
             Ok(())

--- a/qdao-node/exo-pallet/src/lib.rs
+++ b/qdao-node/exo-pallet/src/lib.rs
@@ -9,9 +9,9 @@ use frame_support::{
 };
 use frame_system::Config as SystemConfig;
 pub use pallet::*;
+use qdao_audit_pallet::Game;
 use scale_info::TypeInfo;
 use sp_std::prelude::*;
-use qdao_audit_pallet::{Game};
 
 #[cfg(test)]
 mod mock;


### PR DESCRIPTION
For now:

- makes the project build
- adds an extra unit test which should fail due to insufficient stake
- if we lock the cargo build, we shouldn't remove the .lock file in the CI before buiding, i changed this