### PR TITLE
Auditrep further implementation

### DIFF
--- a/qdao-node/audit-pallet/src/lib.rs
+++ b/qdao-node/audit-pallet/src/lib.rs
@@ -183,10 +183,7 @@ pub mod pallet {
                 <AuditorMap<T>>::try_get(&to_approve).map_err(|_| Error::<T>::UnknownApprovee)?;
 
             // Make sure that has not already auditor status
-            ensure!(
-                to_approve_data.score.is_none(),
-                Error::<T>::AlreadyAuditor,
-            );
+            ensure!(to_approve_data.score.is_none(), Error::<T>::AlreadyAuditor,);
 
             // Make sure that user was not already approved by sender
             ensure!(

--- a/qdao-node/audit-pallet/src/mock.rs
+++ b/qdao-node/audit-pallet/src/mock.rs
@@ -82,7 +82,14 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
         .build_storage::<Test>()
         .unwrap();
     pallet_balances::GenesisConfig::<Test> {
-        balances: vec![(1, 100), (2, 100), (3, 100), (10, 100), (20, 100), (30, 100)],
+        balances: vec![
+            (1, 100),
+            (2, 100),
+            (3, 100),
+            (10, 100),
+            (20, 100),
+            (30, 100),
+        ],
     }
     .assimilate_storage(&mut t)
     .unwrap();

--- a/qdao-node/audit-pallet/src/mock.rs
+++ b/qdao-node/audit-pallet/src/mock.rs
@@ -76,14 +76,6 @@ impl qdao_pallet_dummy::Config for Test {
     type MinAuditorStake = frame_support::traits::ConstU64<100>;
 }
 
-// // Build genesis storage according to the mock runtime.
-// pub fn new_test_ext() -> sp_io::TestExternalities {
-//     system::GenesisConfig::default()
-//         .build_storage::<Test>()
-//         .unwrap()
-//         .into()
-// }
-
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
     let mut t = system::GenesisConfig::default()

--- a/qdao-node/audit-pallet/src/mock.rs
+++ b/qdao-node/audit-pallet/src/mock.rs
@@ -90,7 +90,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
         .build_storage::<Test>()
         .unwrap();
     pallet_balances::GenesisConfig::<Test> {
-        balances: vec![(1, 10), (2, 10), (3, 10), (10, 100), (20, 100), (30, 100)],
+        balances: vec![(1, 100), (2, 100), (3, 100), (10, 100), (20, 100), (30, 100)],
     }
     .assimilate_storage(&mut t)
     .unwrap();

--- a/qdao-node/audit-pallet/src/tests.rs
+++ b/qdao-node/audit-pallet/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{mock::*, AuditorScore, Error};
+use crate::{mock::*, AuditorMap, AuditorScore, Error};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::ensure_signed;
 use sp_core::H256;
@@ -15,10 +15,10 @@ fn sign_up_works() {
         assert_ok!(AuditRepModule::sign_up(Origin::signed(1), hash, 10));
 
         // Then
-        let auditor_score = AuditorScore::<Test>::try_get(sender);
+        let auditor_data = AuditorMap::<Test>::try_get(sender);
         // Check that new Auditor exists with score None and correct Profile
-        assert_eq!(auditor_score.as_ref().unwrap().score, None);
-        assert_eq!(auditor_score.as_ref().unwrap().profile_hash, hash);
+        assert_eq!(auditor_data.as_ref().unwrap().score, None);
+        assert_eq!(auditor_data.as_ref().unwrap().profile_hash, hash);
     });
 }
 

--- a/qdao-node/audit-pallet/src/tests.rs
+++ b/qdao-node/audit-pallet/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{mock::*, AuditorMap, AuditorScore, Error};
+use crate::{mock::*, AuditorMap, Error};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::ensure_signed;
 use sp_core::H256;
@@ -9,10 +9,11 @@ fn sign_up_works() {
         // Given
         let sender = ensure_signed(Origin::signed(1)).unwrap();
         let hash = H256::repeat_byte(1);
+        let stake = 100;
 
         // When
         // Sign up a new auditor, should work
-        assert_ok!(AuditRepModule::sign_up(Origin::signed(1), hash, 10));
+        assert_ok!(AuditRepModule::sign_up(Origin::signed(1), hash, stake));
 
         // Then
         let auditor_data = AuditorMap::<Test>::try_get(sender);

--- a/qdao-node/audit-pallet/src/tests.rs
+++ b/qdao-node/audit-pallet/src/tests.rs
@@ -12,12 +12,13 @@ fn sign_up_works() {
         let stake = 100;
 
         // When
-        // Sign up a new auditor, should work
-        assert_ok!(AuditRepModule::sign_up(Origin::signed(1), hash, stake));
+        // Sign up a new auditor, read the auditor_data from Storage
+        let sign_up_result = AuditRepModule::sign_up(Origin::signed(1), hash, stake);
+        let auditor_data = AuditorMap::<Test>::try_get(sender);
 
         // Then
-        let auditor_data = AuditorMap::<Test>::try_get(sender);
         // Check that new Auditor exists with score None and correct Profile
+        assert_ok!(sign_up_result);
         assert_eq!(auditor_data.as_ref().unwrap().score, None);
         assert_eq!(auditor_data.as_ref().unwrap().profile_hash, hash);
     });
@@ -49,21 +50,21 @@ fn correct_error_for_double_sign_up() {
 
         // When
         // Sign up Auditor, should work
-        assert_ok!(AuditRepModule::sign_up(
-            auditor1.clone(),
-            H256::repeat_byte(1),
-            stake
-        ));
+        let auditor1_sign_up_result =
+            AuditRepModule::sign_up(auditor1.clone(), H256::repeat_byte(1), stake);
         //Sign up second (different) auditor, should also work
-        assert_ok!(AuditRepModule::sign_up(
-            auditor2,
-            H256::repeat_byte(1),
-            stake
-        ));
+        let auditor2_sign_up_result =
+            AuditRepModule::sign_up(auditor2, H256::repeat_byte(1), stake);
         // Sign up an already signed up auditor, should return an error
-        let result = AuditRepModule::sign_up(auditor1, H256::repeat_byte(1), stake);
+        let auditor_1_second_sign_up_result =
+            AuditRepModule::sign_up(auditor1, H256::repeat_byte(1), stake);
 
         // Then
-        assert_noop!(result, Error::<Test>::AlreadySignedUp);
+        assert_ok!(auditor1_sign_up_result);
+        assert_ok!(auditor2_sign_up_result);
+        assert_noop!(
+            auditor_1_second_sign_up_result,
+            Error::<Test>::AlreadySignedUp
+        );
     });
 }


### PR DESCRIPTION
- implements the logic of `approve_auditor` extrinsic
- makes the unit tests work

tbd.: add unit tests for approval workflow