### PR TITLE
Implement game result

### DIFF
--- a/qdao-node/Cargo.lock
+++ b/qdao-node/Cargo.lock
@@ -1040,7 +1040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.6",
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -1943,7 +1943,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -1952,7 +1952,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
- "typenum",
+ "typenum 1.15.0",
  "version_check",
 ]
 
@@ -3258,7 +3258,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -3634,7 +3634,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_distr",
  "simba",
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -4593,6 +4593,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "substrate-fixed",
 ]
 
 [[package]]
@@ -7194,6 +7195,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-fixed"
+version = "0.5.9"
+source = "git+https://github.com/encointer/substrate-fixed#a4fb461aae6205ffc55bed51254a40c52be04e5d"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "typenum 1.16.0",
+]
+
+[[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git#055453ebdf00db9e59ef5af0c59c1b4e39267813"
@@ -7725,6 +7736,15 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "git+https://github.com/encointer/typenum?tag=v1.16.0#4c8dddaa8bdd13130149e43b4085ad14e960617f"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/qdao-node/audit-pallet/Cargo.toml
+++ b/qdao-node/audit-pallet/Cargo.toml
@@ -22,6 +22,8 @@ sp-std = { version = "4.0.0", git="https://github.com/paritytech/substrate.git",
 sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
 serde = { version = "1.0.143", features = ["derive"] }
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
+substrate-fixed = { git = "https://github.com/encointer/substrate-fixed", default-features = false }
+
 
 [dev-dependencies]
 sp-io = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }

--- a/qdao-node/audit-pallet/src/elo_comp.rs
+++ b/qdao-node/audit-pallet/src/elo_comp.rs
@@ -1,36 +1,7 @@
-use substrate_fixed::{FixedI64,transcendental::pow, types::I33F95};
-use sp_runtime::traits::Saturating;
-use sp_runtime::{FixedPointNumber};
+use substrate_fixed::{transcendental::pow, types::I33F95};
 pub struct EloRank {
     pub k: i32,
 }
-
-// Storage for auditors and their score
-//      Auditor ID = pubkey
-//      Score (multiple of them!)
-// History of games?
-
-// Storage for audits and requestors (NFT! this is a link)
-//      Audit_Requestor --> List, NTDNFT owner, vuln approver?
-//      Tags (Rust smart contract ink! AND EVM Solidity) --> can be extended
-
-// Fixed values
-//      elo_ratio
-//      start_score
-//      max_elo_score
-//      min_elo_score
-
-// Functions needed / extrinsics!
-//      sign_up() --> anyone can sign up by paying X coins/fee/stake OR captcha
-//      add_auditor() --> governance only!
-//      remove_auditor() --> governance only! TEMPORARY FUNCTION, eg SUDO
-//      approve_signup --> governance only!
-//      extend_tag() --> governance only!
-//      challange_vuln() --> any signed up auditor
-//          - Uses the EloRank implementation
-//          - Call storage and list it, time limit
-//          - Who wins?
-//      council_challenge_decide() --> governance only! BLACKBELTS
 
 impl EloRank {
     fn calculate_expected(&self, score_a: u32, score_b: u32) -> I33F95 {

--- a/qdao-node/audit-pallet/src/elo_comp.rs
+++ b/qdao-node/audit-pallet/src/elo_comp.rs
@@ -11,16 +11,16 @@ impl EloRank {
     }
 
     pub fn calculate(&self, winner: u32, looser: u32) -> (u32, u32) {
-        let k = self.k as u32;
+        let k = self.k;
 
         let expected_a = self.calculate_expected(winner, looser);
         let expected_b = self.calculate_expected(looser, winner);
 
         let (score_w, score_l) = (1, 0);
-        let winner_new_score = I33F95::from(winner as i16)
-            + I33F95::from(k) * (I33F95::from(score_w as i16) - expected_a);
-        let looser_new_score = I33F95::from(looser as i16)
-            + I33F95::from(k as i16) * (I33F95::from(score_l as i16) - expected_b);
+        let winner_new_score = I33F95::from(winner)
+            + I33F95::from(k) * (I33F95::from(score_w) - expected_a);
+        let looser_new_score = I33F95::from(looser)
+            + I33F95::from(k) * (I33F95::from(score_l) - expected_b);
 
         (
             winner_new_score.round().to_num(),

--- a/qdao-node/audit-pallet/src/elo_comp.rs
+++ b/qdao-node/audit-pallet/src/elo_comp.rs
@@ -17,10 +17,10 @@ impl EloRank {
         let expected_b = self.calculate_expected(looser, winner);
 
         let (score_w, score_l) = (1, 0);
-        let winner_new_score = I33F31::from(winner)
-            + I33F31::from(k) * (I33F31::from(score_w) - expected_a);
-        let looser_new_score = I33F31::from(looser)
-            + I33F31::from(k) * (I33F31::from(score_l) - expected_b);
+        let winner_new_score =
+            I33F31::from(winner) + I33F31::from(k) * (I33F31::from(score_w) - expected_a);
+        let looser_new_score =
+            I33F31::from(looser) + I33F31::from(k) * (I33F31::from(score_l) - expected_b);
 
         (
             winner_new_score.round().to_num(),

--- a/qdao-node/audit-pallet/src/elo_comp.rs
+++ b/qdao-node/audit-pallet/src/elo_comp.rs
@@ -5,10 +5,9 @@ pub struct EloRank {
 
 impl EloRank {
     fn calculate_expected(&self, score_a: u32, score_b: u32) -> I33F95 {
-        let exp = (I33F95::from(score_b) - I33F95::from(score_a))
-            / I33F95::from(400);
-        let res:I33F95 = pow(I33F95::from(10), exp).unwrap();
-        I33F95::from(1) / (I33F95::from(1)+res)
+        let exp = (I33F95::from(score_b) - I33F95::from(score_a)) / I33F95::from(400);
+        let res: I33F95 = pow(I33F95::from(10), exp).unwrap();
+        I33F95::from(1) / (I33F95::from(1) + res)
     }
 
     pub fn calculate(&self, winner: u32, looser: u32) -> (u32, u32) {

--- a/qdao-node/audit-pallet/src/elo_comp.rs
+++ b/qdao-node/audit-pallet/src/elo_comp.rs
@@ -1,13 +1,13 @@
-use substrate_fixed::{transcendental::pow, types::I33F95};
+use substrate_fixed::{transcendental::pow, types::I33F31};
 pub struct EloRank {
     pub k: i32,
 }
 
 impl EloRank {
-    fn calculate_expected(&self, score_a: u32, score_b: u32) -> I33F95 {
-        let exp = (I33F95::from(score_b) - I33F95::from(score_a)) / I33F95::from(400);
-        let res: I33F95 = pow(I33F95::from(10), exp).unwrap();
-        I33F95::from(1) / (I33F95::from(1) + res)
+    fn calculate_expected(&self, score_a: u32, score_b: u32) -> I33F31 {
+        let exp = (I33F31::from(score_b) - I33F31::from(score_a)) / I33F31::from(400);
+        let res: I33F31 = pow(I33F31::from(10), exp).unwrap();
+        I33F31::from(1) / (I33F31::from(1) + res)
     }
 
     pub fn calculate(&self, winner: u32, looser: u32) -> (u32, u32) {
@@ -17,10 +17,10 @@ impl EloRank {
         let expected_b = self.calculate_expected(looser, winner);
 
         let (score_w, score_l) = (1, 0);
-        let winner_new_score = I33F95::from(winner)
-            + I33F95::from(k) * (I33F95::from(score_w) - expected_a);
-        let looser_new_score = I33F95::from(looser)
-            + I33F95::from(k) * (I33F95::from(score_l) - expected_b);
+        let winner_new_score = I33F31::from(winner)
+            + I33F31::from(k) * (I33F31::from(score_w) - expected_a);
+        let looser_new_score = I33F31::from(looser)
+            + I33F31::from(k) * (I33F31::from(score_l) - expected_b);
 
         (
             winner_new_score.round().to_num(),

--- a/qdao-node/audit-pallet/src/elo_comp.rs
+++ b/qdao-node/audit-pallet/src/elo_comp.rs
@@ -6,8 +6,8 @@ pub struct EloRank {
 impl EloRank {
     fn calculate_expected(&self, score_a: u32, score_b: u32) -> I33F31 {
         let exp = (I33F31::from(score_b) - I33F31::from(score_a)) / I33F31::from(400);
-        let res: I33F31 = pow(I33F31::from(10), exp).unwrap();
-        I33F31::from(1) / (I33F31::from(1) + res)
+        let pow_result: I33F31 = pow(I33F31::from(10), exp).unwrap();
+        I33F31::from(1) / (I33F31::from(1) + pow_result)
     }
 
     pub fn calculate(&self, winner: u32, looser: u32) -> (u32, u32) {

--- a/qdao-node/audit-pallet/src/elo_comp.rs
+++ b/qdao-node/audit-pallet/src/elo_comp.rs
@@ -1,0 +1,74 @@
+pub struct EloRank {
+    pub k: i32,
+}
+
+// Storage for auditors and their score
+//      Auditor ID = pubkey
+//      Score (multiple of them!)
+// History of games?
+
+// Storage for audits and requestors (NFT! this is a link)
+//      Audit_Requestor --> List, NTDNFT owner, vuln approver?
+//      Tags (Rust smart contract ink! AND EVM Solidity) --> can be extended
+
+// Fixed values
+//      elo_ratio
+//      start_score
+//      max_elo_score
+//      min_elo_score
+
+// Functions needed / extrinsics!
+//      sign_up() --> anyone can sign up by paying X coins/fee/stake OR captcha
+//      add_auditor() --> governance only!
+//      remove_auditor() --> governance only! TEMPORARY FUNCTION, eg SUDO
+//      approve_signup --> governance only!
+//      extend_tag() --> governance only!
+//      challange_vuln() --> any signed up auditor
+//          - Uses the EloRank implementation
+//          - Call storage and list it, time limit
+//          - Who wins?
+//      council_challenge_decide() --> governance only! BLACKBELTS
+
+impl EloRank {
+    fn calculate_expected(&self, score_a: u32, score_b: u32) -> f32 {
+        1.0 / (1.0 + (10f32.powf((score_b as f32 - score_a as f32) / 400.0)))
+    }
+
+    pub fn calculate(&self, winner: u32, looser: u32) -> (u32, u32) {
+        let k = self.k as u32;
+
+        let expected_a = self.calculate_expected(winner, looser);
+        let expected_b = self.calculate_expected(looser, winner);
+
+        let (score_w, score_l) = (1, 0);
+        let winner_new_score = winner as f32 + k as f32 * (score_w as f32 - expected_a);
+        let looser_new_score = looser as f32 + k as f32 * (score_l as f32 - expected_b);
+
+        (winner_new_score.round() as u32, looser_new_score.round() as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::elo_comp::EloRank;
+
+    #[test]
+    fn calculates_correct_ratings() {
+        let elo = EloRank { k: 32 };
+        let (winner_new, looser_new) = elo.calculate(1200, 1400);
+        assert_eq!(winner_new, 1224);
+        assert_eq!(looser_new, 1376);
+
+        let (winner_new, looser_new) = elo.calculate(1400, 1200);
+        assert_eq!(winner_new, 1408);
+        assert_eq!(looser_new, 1192);
+    }
+
+    #[test]
+    fn rounds_ratings_properly() {
+        let elo = EloRank { k: 32 };
+        let (winner_new, looser_new) = elo.calculate(1802, 1186);
+        assert_eq!(winner_new, 1803);
+        assert_eq!(looser_new, 1185);
+    }
+}

--- a/qdao-node/audit-pallet/src/lib.rs
+++ b/qdao-node/audit-pallet/src/lib.rs
@@ -280,7 +280,7 @@ pub mod pallet {
             player1: T::AccountId,
             winner: Winner,
         ) -> DispatchResult {
-            // Get sender data and check that sender is qualified to approve auditors
+            // Get data and particularly scores of both players
             let mut player0_data =
                 <AuditorMap<T>>::try_get(&player0).map_err(|_| Error::<T>::UnknownAuditor)?;
             let player0_score = player0_data.score.ok_or(Error::<T>::UnapprovedAuditor)?;
@@ -288,24 +288,30 @@ pub mod pallet {
                 <AuditorMap<T>>::try_get(&player1).map_err(|_| Error::<T>::UnknownAuditor)?;
             let player1_score = player1_data.score.ok_or(Error::<T>::UnapprovedAuditor)?;
 
+            
+            // Map winner and looser scores accordingly
             let (winner_score, looser_score) = match winner {
                 Winner::Player0 => (player0_score, player1_score),
                 Winner::Player1 => (player1_score, player0_score),
                 _ => return Ok(())
             };
-
+            
+            // Instantiate EloRank, compute new scores
             let elo = EloRank { k: 32 };
             let (winner_new, looser_new) = elo.calculate(winner_score, looser_score);
 
+            // Map score results accordingly
             (player0_data.score, player1_data.score) = match winner {
                 Winner::Player0 => (Some(winner_new), Some(looser_new)),
                 Winner::Player1 => (Some(looser_new), Some(winner_new)),
                 _ => return Ok(())
             };
 
+            // Write update of player data to runtime storage 
             <AuditorMap<T>>::insert(&player0, player0_data);
             <AuditorMap<T>>::insert(&player1, player1_data);
 
+            // Emit GameResult event
             Self::deposit_event(Event::GameResult {
                 player0,
                 player1,

--- a/qdao-node/audit-pallet/src/lib.rs
+++ b/qdao-node/audit-pallet/src/lib.rs
@@ -288,14 +288,13 @@ pub mod pallet {
                 <AuditorMap<T>>::try_get(&player1).map_err(|_| Error::<T>::UnknownAuditor)?;
             let player1_score = player1_data.score.ok_or(Error::<T>::UnapprovedAuditor)?;
 
-            
             // Map winner and looser scores accordingly
             let (winner_score, looser_score) = match winner {
                 Winner::Player0 => (player0_score, player1_score),
                 Winner::Player1 => (player1_score, player0_score),
-                _ => return Ok(())
+                _ => return Ok(()),
             };
-            
+
             // Instantiate EloRank, compute new scores
             let elo = EloRank { k: 32 };
             let (winner_new, looser_new) = elo.calculate(winner_score, looser_score);
@@ -304,10 +303,10 @@ pub mod pallet {
             (player0_data.score, player1_data.score) = match winner {
                 Winner::Player0 => (Some(winner_new), Some(looser_new)),
                 Winner::Player1 => (Some(looser_new), Some(winner_new)),
-                _ => return Ok(())
+                _ => return Ok(()),
             };
 
-            // Write update of player data to runtime storage 
+            // Write update of player data to runtime storage
             <AuditorMap<T>>::insert(&player0, player0_data);
             <AuditorMap<T>>::insert(&player1, player1_data);
 

--- a/qdao-node/audit-pallet/src/mock.rs
+++ b/qdao-node/audit-pallet/src/mock.rs
@@ -82,6 +82,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     let mut t = system::GenesisConfig::default()
         .build_storage::<Test>()
         .unwrap();
+    // We provide some initial abalances which are high enough for users to sign_up (100 stake required)
     pallet_balances::GenesisConfig::<Test> {
         balances: vec![
             (1, 100),
@@ -94,11 +95,13 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     }
     .assimilate_storage(&mut t)
     .unwrap();
+    // We provide some initial Auditors which are able to approve other Auditors (reputation is high enough)
     let auditor_data = AuditorData::<H256, u64> {
         score: Some(2000),
         profile_hash: H256::repeat_byte(1),
         approved_by: BoundedVec::with_bounded_capacity(3),
     };
+    // We also want Auditors with a reputation score which is not high enough for Approvals, so that an attempted approval fails
     let auditor_data_low_score = AuditorData::<H256, u64> {
         score: Some(1000),
         profile_hash: H256::repeat_byte(1),

--- a/qdao-node/audit-pallet/src/tests.rs
+++ b/qdao-node/audit-pallet/src/tests.rs
@@ -181,8 +181,8 @@ fn elo_score_update_works() {
             AuditRepModule::game_result(Origin::root(), player0_id, player1_id, Winner::Player0);
         let player0_data = AuditorMap::<Test>::try_get(player0_id).unwrap();
         let player1_data = AuditorMap::<Test>::try_get(player1_id).unwrap();
-        let (player0_score, player1_score) = (player0_data.score.unwrap(), player1_data.score.unwrap());
-
+        let (player0_score, player1_score) =
+            (player0_data.score.unwrap(), player1_data.score.unwrap());
 
         // Then
         // Check that Score of Player0 is now higher then Score of Player1 and check for exact scores


### PR DESCRIPTION
- implements the logic behind the `game-result` extrinsic. 
- if we want to compute the Eloscore, we can't use floating point arithmetic in Substrate. But we need to compute exponentials of non-integer numbers to get meaningful result. The PR introduces a fixed point arithmetic by implementing [substrate-fixed](https://github.com/encointer/substrate-fixed) to achieve this.
- adds a meaningful unit test which tests that submitting the game result updates the auditor's score accordingly.