### PR TITLE
Use constants

### DIFF
--- a/qdao-node/audit-pallet/src/lib.rs
+++ b/qdao-node/audit-pallet/src/lib.rs
@@ -61,6 +61,10 @@ pub mod pallet {
         #[pallet::constant] // put the constant in metadata
         /// Minimum amount which is required for an Auditor to be able to sign up.
         type MinAuditorStake: Get<DepositBalanceOf<Self>>;
+
+        #[pallet::constant] // put the constant in metadata
+        /// Initial score for an auditor which signed up and received 3 approvals
+        type InitialAuditorScore: Get<u32>;
     }
 
     #[pallet::pallet]
@@ -238,7 +242,7 @@ pub mod pallet {
 
             // If user has 3 approvals, give user Auditor status
             if to_approve_data.approved_by.len() == 3 {
-                to_approve_data.score = Some(1000);
+                to_approve_data.score = Some(T::InitialAuditorScore::get());
             }
 
             // Update user data

--- a/qdao-node/audit-pallet/src/lib.rs
+++ b/qdao-node/audit-pallet/src/lib.rs
@@ -65,6 +65,10 @@ pub mod pallet {
         #[pallet::constant] // put the constant in metadata
         /// Initial score for an auditor which signed up and received 3 approvals
         type InitialAuditorScore: Get<u32>;
+
+        #[pallet::constant] // put the constant in metadata
+        /// Minimal score which allows auditors to approve other auditors
+        type MinimalApproverScore: Get<u32>;
     }
 
     #[pallet::pallet]
@@ -219,7 +223,7 @@ pub mod pallet {
             let sender_data =
                 <AuditorMap<T>>::try_get(&sender).map_err(|_| Error::<T>::UnknownAuditor)?;
             let sender_score = sender_data.score.ok_or(Error::<T>::UnapprovedAuditor)?;
-            ensure!(sender_score >= 2000, Error::<T>::ReputationTooLow);
+            ensure!(sender_score >= T::MinimalApproverScore::get(), Error::<T>::ReputationTooLow);
 
             // Get data of user which should get approved
             let mut to_approve_data =

--- a/qdao-node/audit-pallet/src/lib.rs
+++ b/qdao-node/audit-pallet/src/lib.rs
@@ -223,7 +223,10 @@ pub mod pallet {
             let sender_data =
                 <AuditorMap<T>>::try_get(&sender).map_err(|_| Error::<T>::UnknownAuditor)?;
             let sender_score = sender_data.score.ok_or(Error::<T>::UnapprovedAuditor)?;
-            ensure!(sender_score >= T::MinimalApproverScore::get(), Error::<T>::ReputationTooLow);
+            ensure!(
+                sender_score >= T::MinimalApproverScore::get(),
+                Error::<T>::ReputationTooLow
+            );
 
             // Get data of user which should get approved
             let mut to_approve_data =

--- a/qdao-node/audit-pallet/src/mock.rs
+++ b/qdao-node/audit-pallet/src/mock.rs
@@ -76,7 +76,7 @@ impl qdao_pallet_dummy::Config for Test {
     type Currency = Balances;
     type MinAuditorStake = frame_support::traits::ConstU64<100>;
     type InitialAuditorScore = frame_support::traits::ConstU32<1000>;
-    type InitialApproverScore = frame_support::traits::ConstU32<2000>;
+    type MinimalApproverScore = frame_support::traits::ConstU32<2000>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/qdao-node/audit-pallet/src/mock.rs
+++ b/qdao-node/audit-pallet/src/mock.rs
@@ -76,6 +76,7 @@ impl qdao_pallet_dummy::Config for Test {
     type Currency = Balances;
     type MinAuditorStake = frame_support::traits::ConstU64<100>;
     type InitialAuditorScore = frame_support::traits::ConstU32<1000>;
+    type InitialApproverScore = frame_support::traits::ConstU32<2000>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/qdao-node/audit-pallet/src/mock.rs
+++ b/qdao-node/audit-pallet/src/mock.rs
@@ -75,6 +75,7 @@ impl qdao_pallet_dummy::Config for Test {
     type Balance = u64;
     type Currency = Balances;
     type MinAuditorStake = frame_support::traits::ConstU64<100>;
+    type InitialAuditorScore = frame_support::traits::ConstU32<1000>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/qdao-node/runtime/src/lib.rs
+++ b/qdao-node/runtime/src/lib.rs
@@ -147,6 +147,7 @@ parameter_types! {
     pub const SS58Prefix: u8 = 42;
     pub const MinAuditorStake: Balance = 100;
     pub const InitialAuditorScore: u32 = 1000;
+    pub const MinimalApproverScore: u32 = 2000;
 }
 
 // Configure FRAME pallets to include in runtime.
@@ -277,6 +278,7 @@ impl qdao_audit_pallet::Config for Runtime {
     type Currency = Balances;
     type MinAuditorStake = MinAuditorStake;
     type InitialAuditorScore = InitialAuditorScore;
+    type MinimalApproverScore = MinimalApproverScore;
 }
 
 /// Configure the qdao-exo-pallet.

--- a/qdao-node/runtime/src/lib.rs
+++ b/qdao-node/runtime/src/lib.rs
@@ -146,6 +146,7 @@ parameter_types! {
         ::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
     pub const SS58Prefix: u8 = 42;
     pub const MinAuditorStake: Balance = 100;
+    pub const InitialAuditorScore: u32 = 1000;
 }
 
 // Configure FRAME pallets to include in runtime.
@@ -275,6 +276,7 @@ impl qdao_audit_pallet::Config for Runtime {
     type Balance = Balance;
     type Currency = Balances;
     type MinAuditorStake = MinAuditorStake;
+    type InitialAuditorScore = InitialAuditorScore;
 }
 
 /// Configure the qdao-exo-pallet.


### PR DESCRIPTION
Replaces hardcoded valus with [runtime constants](https://docs.substrate.io/reference/how-to-guides/basics/configure-runtime-constants/) for:

- InitialAuditorScore
- MinimalApproverScore