### PR TITLE
Catch pow error

### DIFF
--- a/qdao-node/audit-pallet/src/elo_comp.rs
+++ b/qdao-node/audit-pallet/src/elo_comp.rs
@@ -4,17 +4,17 @@ pub struct EloRank {
 }
 
 impl EloRank {
-    fn calculate_expected(&self, score_a: u32, score_b: u32) -> I33F31 {
+    fn calculate_expected(&self, score_a: u32, score_b: u32) -> Result<I33F31, ()> {
         let exp = (I33F31::from(score_b) - I33F31::from(score_a)) / I33F31::from(400);
-        let pow_result: I33F31 = pow(I33F31::from(10), exp).unwrap();
-        I33F31::from(1) / (I33F31::from(1) + pow_result)
+        let pow_result: I33F31 = pow(I33F31::from(10), exp)?;
+        Ok(I33F31::from(1) / (I33F31::from(1) + pow_result))
     }
 
-    pub fn calculate(&self, winner: u32, looser: u32) -> (u32, u32) {
+    pub fn calculate(&self, winner: u32, looser: u32) -> Result<(u32, u32), ()> {
         let k = self.k;
 
-        let expected_a = self.calculate_expected(winner, looser);
-        let expected_b = self.calculate_expected(looser, winner);
+        let expected_a = self.calculate_expected(winner, looser)?;
+        let expected_b = self.calculate_expected(looser, winner)?;
 
         let (score_w, score_l) = (1, 0);
         let winner_new_score =
@@ -22,10 +22,10 @@ impl EloRank {
         let looser_new_score =
             I33F31::from(looser) + I33F31::from(k) * (I33F31::from(score_l) - expected_b);
 
-        (
+        Ok((
             winner_new_score.round().to_num(),
             looser_new_score.round().to_num(),
-        )
+        ))
     }
 }
 
@@ -36,11 +36,11 @@ mod tests {
     #[test]
     fn calculates_correct_ratings() {
         let elo = EloRank { k: 32 };
-        let (winner_new, looser_new) = elo.calculate(1200, 1400);
+        let (winner_new, looser_new) = elo.calculate(1200, 1400).expect("Unexpected overflow");
         assert_eq!(winner_new, 1224);
         assert_eq!(looser_new, 1376);
 
-        let (winner_new, looser_new) = elo.calculate(1400, 1200);
+        let (winner_new, looser_new) = elo.calculate(1400, 1200).expect("Unexpected overflow");
         assert_eq!(winner_new, 1408);
         assert_eq!(looser_new, 1192);
     }
@@ -48,7 +48,7 @@ mod tests {
     #[test]
     fn rounds_ratings_properly() {
         let elo = EloRank { k: 32 };
-        let (winner_new, looser_new) = elo.calculate(1802, 1186);
+        let (winner_new, looser_new) = elo.calculate(1802, 1186).expect("Unexpected overflow");
         assert_eq!(winner_new, 1803);
         assert_eq!(looser_new, 1185);
     }

--- a/qdao-node/audit-pallet/src/lib.rs
+++ b/qdao-node/audit-pallet/src/lib.rs
@@ -296,7 +296,9 @@ pub mod pallet {
 
             // Instantiate EloRank, compute new scores
             let elo = EloRank { k: 32 };
-            let (winner_new, looser_new) = elo.calculate(winner_score, looser_score).map_err(|_| Error::<T>::UnexpectedEloOverflow)?;
+            let (winner_new, looser_new) = elo
+                .calculate(winner_score, looser_score)
+                .map_err(|_| Error::<T>::UnexpectedEloOverflow)?;
 
             // Map score results accordingly
             (player0_data.score, player1_data.score) = match winner {

--- a/qdao-node/audit-pallet/src/lib.rs
+++ b/qdao-node/audit-pallet/src/lib.rs
@@ -147,6 +147,8 @@ pub mod pallet {
         AlreadyAuditor,
         // The approvee already received an approval by the sender
         AlreadyApproved,
+        // Eloscore computational overflow (expected not to happen with Eloscore formula)
+        UnexpectedEloOverflow,
     }
 
     // Dispatchable functions allows users to interact with the pallet and invoke state changes.
@@ -294,7 +296,7 @@ pub mod pallet {
 
             // Instantiate EloRank, compute new scores
             let elo = EloRank { k: 32 };
-            let (winner_new, looser_new) = elo.calculate(winner_score, looser_score);
+            let (winner_new, looser_new) = elo.calculate(winner_score, looser_score).map_err(|_| Error::<T>::UnexpectedEloOverflow)?;
 
             // Map score results accordingly
             (player0_data.score, player1_data.score) = match winner {


### PR DESCRIPTION
The `substrate_fixed::transcendental::pow` function could (theoretically) overflow. To prevent this overflow from causing a runtime error, this PR implements a proper error handling for it.