### PR TITLE
Configure genesis

### DIFF
--- a/qdao-node/audit-pallet/src/lib.rs
+++ b/qdao-node/audit-pallet/src/lib.rs
@@ -75,15 +75,15 @@ pub mod pallet {
         /// Currency mechanism
         type Currency: ReservableCurrency<Self::AccountId>;
 
-        #[pallet::constant] 
+        #[pallet::constant]
         /// Minimum amount which is required for an Auditor to be able to sign up.
         type MinAuditorStake: Get<DepositBalanceOf<Self>>;
 
-        #[pallet::constant] 
+        #[pallet::constant]
         /// Initial score for an auditor which signed up and received 3 approvals
         type InitialAuditorScore: Get<u32>;
 
-        #[pallet::constant] 
+        #[pallet::constant]
         /// Minimal score which allows auditors to approve other auditors
         type MinimalApproverScore: Get<u32>;
     }
@@ -129,7 +129,6 @@ pub mod pallet {
         }
     }
 
-    
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     /// Events which are emitted by `qdao-audit-pallet`
@@ -144,7 +143,6 @@ pub mod pallet {
         },
     }
 
-    
     #[pallet::error]
     /// Errors of `qdao-audit-pallet`
     pub enum Error<T> {
@@ -229,7 +227,7 @@ pub mod pallet {
 
         #[pallet::weight(Weight::from_ref_time(10_000) + T::DbWeight::get().writes(1))]
 
-        /// Is called by an auditor which signed up for auditor status to cancel their 
+        /// Is called by an auditor which signed up for auditor status to cancel their
         /// account and to unreserve the associated funds.
         ///
         pub fn cancel_account(origin: OriginFor<T>) -> DispatchResult {

--- a/qdao-node/client/src/chain_spec.rs
+++ b/qdao-node/client/src/chain_spec.rs
@@ -1,13 +1,13 @@
-use qdao_audit_pallet::pallet::GenesisConfig as AuditConfig;
+use qdao_audit_pallet::{pallet::GenesisConfig as AuditConfig, AuditorData};
 use qdao_runtime::{
     AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig,
     SystemConfig, WASM_BINARY,
 };
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{sr25519, Pair, Public};
+use sp_core::{sr25519, Pair, Public, H256};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
-use sp_runtime::traits::{IdentifyAccount, Verify};
+use sp_runtime::{traits::{IdentifyAccount, Verify}, BoundedVec};
 
 // The URL for the telemetry server.
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -57,6 +57,8 @@ pub fn development_config() -> Result<ChainSpec, String> {
                 vec![
                     get_account_id_from_seed::<sr25519::Public>("Alice"),
                     get_account_id_from_seed::<sr25519::Public>("Bob"),
+                    get_account_id_from_seed::<sr25519::Public>("Charlie"),
+                    get_account_id_from_seed::<sr25519::Public>("Dave"),
                     get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
                 ],
@@ -136,6 +138,11 @@ fn testnet_genesis(
     endowed_accounts: Vec<AccountId>,
     _enable_println: bool,
 ) -> GenesisConfig {
+    let auditor_data = AuditorData::<H256, AccountId> {
+        score: Some(2000),
+        profile_hash: H256::repeat_byte(1),
+        approved_by: BoundedVec::with_bounded_capacity(3),
+    };
     GenesisConfig {
         system: SystemConfig {
             // Add Wasm runtime to storage.
@@ -163,6 +170,12 @@ fn testnet_genesis(
             key: Some(root_key),
         },
         transaction_payment: Default::default(),
-        audit_module: AuditConfig::default(),
+        audit_module: AuditConfig {
+            auditor_map: vec![
+                (endowed_accounts.get(0).unwrap().clone(), auditor_data.clone()),
+                (endowed_accounts.get(1).unwrap().clone(), auditor_data.clone()),
+                (endowed_accounts.get(2).unwrap().clone(), auditor_data),
+            ],
+        },
     }
 }

--- a/qdao-node/client/src/chain_spec.rs
+++ b/qdao-node/client/src/chain_spec.rs
@@ -7,7 +7,10 @@ use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{sr25519, Pair, Public, H256};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
-use sp_runtime::{traits::{IdentifyAccount, Verify}, BoundedVec};
+use sp_runtime::{
+    traits::{IdentifyAccount, Verify},
+    BoundedVec,
+};
 
 // The URL for the telemetry server.
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -59,6 +62,8 @@ pub fn development_config() -> Result<ChainSpec, String> {
                     get_account_id_from_seed::<sr25519::Public>("Bob"),
                     get_account_id_from_seed::<sr25519::Public>("Charlie"),
                     get_account_id_from_seed::<sr25519::Public>("Dave"),
+                    get_account_id_from_seed::<sr25519::Public>("Eve"),
+                    get_account_id_from_seed::<sr25519::Public>("Ferdie"),
                     get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
                 ],
@@ -172,9 +177,19 @@ fn testnet_genesis(
         transaction_payment: Default::default(),
         audit_module: AuditConfig {
             auditor_map: vec![
-                (endowed_accounts.get(0).unwrap().clone(), auditor_data.clone()),
-                (endowed_accounts.get(1).unwrap().clone(), auditor_data.clone()),
-                (endowed_accounts.get(2).unwrap().clone(), auditor_data),
+                (
+                    endowed_accounts.get(0).unwrap().clone(),
+                    auditor_data.clone(),
+                ),
+                (
+                    endowed_accounts.get(1).unwrap().clone(),
+                    auditor_data.clone(),
+                ),
+                (
+                    endowed_accounts.get(2).unwrap().clone(),
+                    auditor_data.clone(),
+                ),
+                (endowed_accounts.get(3).unwrap().clone(), auditor_data),
             ],
         },
     }


### PR DESCRIPTION
Adds a genesis configs of pre-defined auditor accounts to the `qdao-node` which allows for  on-chain testing of the auditor sign-up workflos.